### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Pietro's Image Gallery
 A self-contained server and webpage to allow the user to upload and host static image files.
+[![Run on Repl.it](https://repl.it/badge/github/Sonnysboy/pietros-image-gallery)](https://repl.it/github/Sonnysboy/pietros-image-gallery)
 
 ![Demo GIF](http://pietro.adnan-chowdhury.com/uploads/1421529837299pietro.gif)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Sonnysboy/pietros-image-gallery).